### PR TITLE
added 'ssd1306_tiny_init()' to save flash memory if an initial screen fill is not required (~52 bytes shorter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ void run() {
 
 - Library functions
     - `void ssd1306_init(void)`: initializes the screen
+    - `void ssd1306_tiny_init(void)`: initializes the screen without filling the screen with '0'
     - `void ssd1306_send_data_start(void)`: put the communication with a screen in data mode
     - `void ssd1306_send_data_stop(void)`: stops the communication 
     - `void ssd1306_send_byte(uint8_t byte)`: send data byte to screen
@@ -65,6 +66,8 @@ This code is mainly written by Neven Boyanov, Tinusar team. I replaced their I2C
 ### Versions
 - v0.0.1 (March 08, 2020)
     - initial release
+- v0.0.2 (July 07, 2024)
+    - added 'ssd1306_tiny_init()' to save flash memory if an initial screen fill is not required (~52 bytes shorter)
 
 
 

--- a/ssd1306xled.cpp
+++ b/ssd1306xled.cpp
@@ -165,6 +165,20 @@ void SSD1306Device::ssd1306_init(void)
 	ssd1306_fillscreen(0);
 }
 
+// A shorter init saves 52 flash bytes (if zeroed screen is not required)
+// The code of 'ssd1306_init()' is replicated to allow the linker to drop the unused method during linkage.
+void SSD1306Device::ssd1306_tiny_init(void)
+{
+	begin();
+	ssd1306_send_command_start();
+	for (uint8_t i = 0; i < sizeof (ssd1306_init_sequence); i++) {
+		ssd1306_send_byte(pgm_read_byte(&ssd1306_init_sequence[i]));
+	}
+	ssd1306_send_command_stop();
+	// save 52 bytes :)
+	//ssd1306_fillscreen(0);
+}
+
 void SSD1306Device::ssd1306_send_command_start(void) {
 	I2CStop();
 	I2CStart(SSD1306_SA, 0);

--- a/ssd1306xled.h
+++ b/ssd1306xled.h
@@ -19,6 +19,9 @@
 #ifndef SSD1306XLED_H
 #define SSD1306XLED_H
 
+#define _SSD1306XLED_TINY_INIT_SUPPORTED_
+
+
 // ----------------------------------------------------------------------------
 
 // -----(+)--------------->	// Vcc,	Pin 1 on SSD1306 Board
@@ -73,6 +76,7 @@ class SSD1306Device
     public:
 		SSD1306Device(void);
 		void ssd1306_init(void);
+		void ssd1306_tiny_init(void);
 
 		void ssd1306_send_data_start(void);
 		void ssd1306_send_data_stop(void);


### PR DESCRIPTION
Hi Tejashwi,

I found your repository when I was looking for a 'cleaner' SSD1306 library for ATtiny85.
It works great, but requires 180 bytes more flash memory.
Because I'm really low on flash memory, I had a look into your code and saw that you always call `ssd1306_fillscreen()` on `ssd1306_init()`. For my application this is unnecessary and so I implemented an additional initialization method `ssd1306_tiny_init()` which saves 52 bytes.

The change should not interfere with your code in any way, so I thought you might think about integrating it into the 'official' repository.

I added a #define allowing code to work with any version of the library:

```javascript
  #if defined( _SSD1306XLED_TINY_INIT_SUPPORTED_ )
    // library supports shorter init method
    SSD1306.ssd1306_tiny_init();
  #else
    // use standard init method
    SSD1306.ssd1306_init();
  #endif
```

Additional 28 bytes could be saved by enabling `TINY4KOLED_QUICK_BEGIN`, but that would be a breaking change.
Of course I kept that untouched ;)

Stay safe,
Sven